### PR TITLE
Addition of C and new networking course

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ Courses | Duration | Effort | Prerequisites
 [Software Architecture](https://www.coursera.org/learn/software-architecture) | 4 weeks | 2-5 hours/week | Design Patterns
 [Build a Modern Computer from First Principles: From Nand to Tetris](https://www.coursera.org/learn/build-a-computer) ([alt](https://www.nand2tetris.org/)) | 6 weeks | 7-13 hours/week | - | C-like programming language
 [Build a Modern Computer from First Principles: Nand to Tetris Part II ](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | - | one of [these programming languages](https://user-images.githubusercontent.com/2046800/35426340-f6ce6358-026a-11e8-8bbb-4e95ac36b1d7.png), From Nand to Tetris Part I
-[Operating Systems: Three Easy Pieces](coursepages/ostep/OSTEP.md) | 10-12 weeks | 6-10 hours/week | - | strong C programming
-[Computer Networking: a Top-Down Approach](http://gaia.cs.umass.edu/kurose_ross/online_lectures.htm)| 8 weeks | 4–12 hours/week | [Wireshark Labs](http://gaia.cs.umass.edu/kurose_ross/wireshark.php) | algebra, probability, basic CS
+[C For Everyone: Programming Fundamentals ](https://www.coursera.org/learn/c-for-everyone) | 3-4 weeks | 12-15 hours/week | -
+[C For Everyone: Structured Programming ](https://www.coursera.org/learn/c-structured-programming) | 2 weeks | 5 hours/week | -
+[Operating Systems: Three Easy Pieces](coursepages/ostep/OSTEP.md) | 10-12 weeks | 6-10 hours/week | - | C programming
+[Computer Networking](https://www.udacity.com/course/computer-networking--ud436) | 12 weeks | 5-8 hours/week | -
 
 ### Core ethics
 


### PR DESCRIPTION
Replace old computer networking top down approach course with a more comprehensive one from coursera. Introduce 2 C courses to prepare students for proceeding Operating Systems course.