### PR TITLE
Replaced Parallel Programming course

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ But students should take *every* course that is relevant to the field they inten
 Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Architecture 1001: x86-64 Assembly](https://p.ost2.fyi/courses/course-v1:OpenSecurityTraining2+Arch1001_x86-64_Asm+2021_v1/about) | 8 weeks | 10-15 hours/week | C programming
-[Parallel Programming](https://www.coursera.org/learn/scala-parallel-programming)| 4 weeks | 6-8 hours/week | Scala programming
+[Parallel Programming in Java](https://www.coursera.org/learn/parallel-programming-in-java#syllabus)| 4 weeks | 5 hours/week | Java programming
 [Compilers](https://www.edx.org/course/compilers) | 9 weeks | 6-8 hours/week | none
 [Software Debugging](https://www.udacity.com/course/software-debugging--cs259)| 8 weeks | 6 hours/week | Python, object-oriented programming
 [Software Testing](https://www.udacity.com/course/software-testing--cs258) | 4 weeks | 6 hours/week | Python, programming experience


### PR DESCRIPTION
Replaced Scala parallel programming with Java parallel programming course, because we don't have any Scala courses in the curriculum.